### PR TITLE
fix: Attempt to fix `update-flake-lock` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,9 @@ jobs:
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
-          # Note: SSH_KEY_PINT_NIX may not be necessary, but trying everything.
           ssh-private-key: |
               ${{ secrets.SSH_KEY_BASE }}
               ${{ secrets.SSH_KEY_PINT }}
-              ${{ secrets.SSH_KEY_PINT_NIX }}
       - run: |
           git ls-remote ssh://git@github.com/essential-contributions/${{ matrix.repo }}.git HEAD
 
@@ -58,7 +56,6 @@ jobs:
           ssh-private-key: |
               ${{ secrets.SSH_KEY_BASE }}
               ${{ secrets.SSH_KEY_PINT }}
-              ${{ secrets.SSH_KEY_PINT_NIX }}
       - uses: DeterminateSystems/nix-installer-action@v10
       - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: nix ${{ matrix.command }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: webfactory/ssh-agent@v0.9.0
         with:
+          # Note this includes SSH access to our own repo too.
+          # This is necessary for the action to push to the `update_flake_lock_action` branch.
           ssh-private-key: |
               ${{ secrets.SSH_KEY_BASE }}
               ${{ secrets.SSH_KEY_PINT }}


### PR DESCRIPTION
While the CI is succeeding here, the workflow that is failing can be found in `Actions > update-flake-lock`. The `DeterminateSystems/update-flake-lock` action is failing with a pretty obscure error. My suspicion is it is not receiving access to the ssh-agent for some reason.

I've opened an issue to track here: https://github.com/DeterminateSystems/update-flake-lock/issues/102