### PR TITLE
fix: Switch to stable release from from `update-flake-lock`

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -38,7 +38,7 @@ jobs:
             echo "pr_title=Update flake.lock inputs: pint-src" >> $GITHUB_ENV
           fi
       - name: Update flake inputs
-        uses: DeterminateSystems/update-flake-lock@main
+        uses: DeterminateSystems/update-flake-lock@v21
         with:
           inputs: ${{ env.inputs }}
           token: ${{ secrets.GH_PAT_FOR_CI_UPDATES }}


### PR DESCRIPTION
The `main` branch just made an update that seems to be causing some breakage. By pinning to a specific version, hopefully we avoid this kind of issue going forward.